### PR TITLE
Fix incompatibility with crystal-25.0

### DIFF
--- a/src/crystal-dfa/parser.cr
+++ b/src/crystal-dfa/parser.cr
@@ -111,7 +111,7 @@ module DFA
     def consume(_type : Symbol)
       _next = consume
       unless _next && _next[:type] == _type
-        raise "expected `#{Lexer::IDENTIFIERS.key?(_type)||_type}` got `#{_next}`"
+        raise "expected `#{Lexer::IDENTIFIERS.key_for?(_type)||_type}` got `#{_next}`"
       end
       _next
     end
@@ -168,7 +168,7 @@ module DFA
                   # their string representation because
                   # we won't interprete them inside a
                   # characterclass
-                  Lexer::IDENTIFIERS.key(_next[:type])
+                  Lexer::IDENTIFIERS.key_for(_next[:type])
 
         case value
         when 's' then AST::LiteralNode.new(WHITESPACE_RANGES.first.begin)


### PR DESCRIPTION
In 25.0 Hash#key? and Hash#key are renamed to Hash#key_for? and Hash#key_for
