### PR TITLE
Syntax fixes for compatiblity with Crystal 1.7.1

### DIFF
--- a/spec/crystal-dfa/nfa_spec.cr
+++ b/spec/crystal-dfa/nfa_spec.cr
@@ -8,7 +8,7 @@ describe DFA::NFA do
       DFA::NFA.create_nfa(ast).should eq expected
     end
 
-    it "creates a state for a ConcateNode" do
+    describe "creates a state for a ConcateNode" do
       it "works for the binary case" do
         ast = DFA::AST::ConcatNode.new [
           DFA::AST::LiteralNode.new('a').as(DFA::AST::ASTNode),
@@ -31,7 +31,7 @@ describe DFA::NFA do
       end
     end
 
-    it "creates a state for an AlternationNode" do
+    describe "creates a state for an AlternationNode" do
       it "works for the binary case" do
         ast = DFA::AST::AlternationNode.new [
           DFA::AST::LiteralNode.new('a').as(DFA::AST::ASTNode),
@@ -99,7 +99,7 @@ describe DFA::NFA do
         DFA::NFA.create_nfa(ast).should eq expected
       end
 
-      it "creates a state for a CharacterClassNode([a-z]) One-or-More" do
+      describe "creates a state for a CharacterClassNode([a-z]) One-or-More" do
         it "creates a state for the simple range case [a-z]" do
           ast = DFA::AST::CharacterClassNode.new(false, Array(String).new, [('a'..'z')])
           expected = r_state('a', 'z')

--- a/src/core_ext/range.cr
+++ b/src/core_ext/range.cr
@@ -47,7 +47,7 @@ module IntersectionMethods(T)
   end
 end
 
-struct Tuple(T)
+struct Tuple(*T)
   include IntersectionMethods(T)
 
   def -(other : self)

--- a/src/crystal-dfa/parser.cr
+++ b/src/crystal-dfa/parser.cr
@@ -143,19 +143,19 @@ module DFA
     end
 
     class NameParslet < PrefixParslet
-      def parse(parser, token)
+      def parse(parser, token) : AST::ASTNode
         AST::LiteralNode.new(token[:value].not_nil!)
       end
     end
 
     class AnyCharacterParslet < PrefixParslet
-      def parse(parser, token)
+      def parse(parser, token) : AST::ASTNode
         AST::CharacterClassNode.new(false, Array(String).new, ANY_CHAR_RANGES)
       end
     end
 
     class SpecialCharacterClassParslet < PrefixParslet
-      def parse(parser, token)
+      def parse(parser, token) : AST::ASTNode
         _next = parser.consume
         raise "unexpected end of input" unless _next
 
@@ -180,7 +180,7 @@ Lexer::IDENTIFIERS.key_for(_next[:type])
     end
 
     class GroupParslet < PrefixParslet
-      def parse(parser, token)
+      def parse(parser, token) : AST::ASTNode
         # ignore non capturing group designators
         if (_peek = parser.peek) &&
            _peek[:type] == :QSTM
@@ -199,7 +199,7 @@ Lexer::IDENTIFIERS.key_for(_next[:type])
     end
 
     class CharacterRangeParslet < InfixParslet
-      def parse(parser, left, token)
+      def parse(parser, left, token) : AST::ASTNode
         parser.consume(:MINUS)
         right = parser.parseExpression(precedence)
 
@@ -218,7 +218,7 @@ Lexer::IDENTIFIERS.key_for(_next[:type])
     end
 
     class CharacterClassParslet < PrefixParslet
-      def parse(parser, token)
+      def parse(parser, token) : AST::ASTNode
         negate = (peek = parser.peek) &&
                  (peek[:type] == :NEGATE) &&
                  parser.consume ? true : false
@@ -266,7 +266,7 @@ Lexer::IDENTIFIERS.key_for(_next[:type])
     end
 
     class ConcatParslet < InfixParslet
-      def parse(parser, left : AST::ASTNode, token)
+      def parse(parser, left : AST::ASTNode, token) : AST::ASTNode
         exp = AST::ConcatNode.new([left.as(AST::ASTNode)])
 
         _next = parser.parseExpression(Precedence[:LITERAL] - 1).as(AST::ASTNode?)
@@ -282,7 +282,7 @@ Lexer::IDENTIFIERS.key_for(_next[:type])
     end
 
     class CurlyQuantifierParslet < InfixParslet
-      def parse(parser, left : AST::ASTNode, token)
+      def parse(parser, left : AST::ASTNode, token) : AST::ASTNode
         parser.consume(:LCURLY)
 
         values = parse_quantifications(
@@ -318,14 +318,14 @@ Lexer::IDENTIFIERS.key_for(_next[:type])
     end
 
     class QuantifierParslet(T) < InfixParslet
-      def parse(parser, left : AST::ASTNode, token)
+      def parse(parser, left : AST::ASTNode, token) : AST::ASTNode
         parser.consume
         T.new(left)
       end
     end
 
     class AlternationParslet < InfixParslet
-      def parse(parser, left : AST::ASTNode, token)
+      def parse(parser, left : AST::ASTNode, token) : AST::ASTNode
         exp = AST::AlternationNode.new([left.as(AST::ASTNode)])
         while (peek = parser.peek) && (peek[:type] == :PIPE)
           parser.consume


### PR DESCRIPTION
Hi @ziprandom! Thank you for this library.  I'd like to bring it up to date as to bring your cltk project up to date.

This commit brings this lib up to date with newer Crystal by addressing explicit return types and spec behavior.

* Uses `describe` instead nesting `it` blocks
* Uses explicit return types for abstract def implementations
* Uses a splatted Tuple generic

I'll work off my branches for now, but I'd love to see your great work here come up to date!